### PR TITLE
Adjustments to compile the dgmare-handover branch

### DIFF
--- a/module/src/main/application/META-INF/jboss-all.xml
+++ b/module/src/main/application/META-INF/jboss-all.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <jboss umlns="urn:jboss:1.0">
     <jboss-deployment-dependencies xmlns="urn:jboss:deployment-dependencies:1.0">
-        <dependency name="user-module-${jboss.all.user.dependency.version}.ear"/>
-        <dependency name="config-module-${jboss.all.config.dependency.version}.ear"/>
+        <dependency name="${jboss.all.user.dependency}"/>
+        <dependency name="${jboss.all.config.dependency}"/>
     </jboss-deployment-dependencies>
 </jboss>

--- a/pom.xml
+++ b/pom.xml
@@ -41,9 +41,18 @@
         <lombok.version>1.16.18</lombok.version>
 
         <!-- jboss-all.xml dependency properties -->
+        <!--
+            These properties are used to build the module/src/main/application/META-INF/jboss-all.xml.
+            Since the needs for local deployment are different from those of production, the jboss.all.*.dependency
+            properties can be overridden in your local settings.xml. The following snippet should work:
+
+                <jboss.all.user.dependency>user-module.ear</jboss.all.user.dependency>
+                <jboss.all.config.dependency>config-module.ear</jboss.all.config.dependency>
+        -->
         <jboss.all.user.dependency.version>2.0.15-W14J8</jboss.all.user.dependency.version>
         <jboss.all.config.dependency.version>4.0.13-W14J8</jboss.all.config.dependency.version>
-
+        <jboss.all.user.dependency>user-module-${jboss.all.user.dependency.version}.ear</jboss.all.user.dependency>
+        <jboss.all.config.dependency>config-module-${jboss.all.user.dependency}.ear</jboss.all.config.dependency>
     </properties>
 
     <dependencies>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -28,6 +28,11 @@
 
     <dependencies>
         <dependency>
+            <groupId>eu.europa.ec.fisheries.uvms.config</groupId>
+            <artifactId>config-model</artifactId>
+            <version>4.0.11</version>
+        </dependency>
+        <dependency>
             <groupId>eu.europa.ec.fisheries.uvms.exchange</groupId>
             <artifactId>exchange-model</artifactId>
             <version>${exchange.model.version}</version>


### PR DESCRIPTION
About the change in the usage of the `jboss.all.*.dependency.*` properties:

The existing build adds the `jboss-all.xml` file in the EAR to declare dependencies on other projects. The artifact names of these projects contain the version of the dependency in the production build, but not in the local build. The `jboss.all.*.dependency` properties keep the same behavior in production builds, but allow you to override the name of the dependency locally.